### PR TITLE
Fix UI issues in notes and contacts listing pages

### DIFF
--- a/app/javascript/src/components/Dashboard/Contacts/ContactTable.jsx
+++ b/app/javascript/src/components/Dashboard/Contacts/ContactTable.jsx
@@ -73,14 +73,10 @@ export default function ConatactTable({
                     <Checkbox checked={contact.addToBaseCamp} />
                   </div>
                 </td>
-                <td className="text-center">
-                  <div className="flex">
+                <td>
+                  <div className="flex flex-row items-center justify-center space-x-3">
                     <Tooltip content="Edit" position="bottom">
-                      <Button
-                        className="mr-2"
-                        style="icon"
-                        icon="ri-pencil-line"
-                      />
+                      <Button style="icon" icon="ri-pencil-line" />
                     </Tooltip>
                     <Tooltip content="Delete" position="bottom">
                       <Button

--- a/app/javascript/src/components/Dashboard/Contacts/NewContactForm.jsx
+++ b/app/javascript/src/components/Dashboard/Contacts/NewContactForm.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Formik, Form } from "formik";
 import { Input, Switch } from "neetoui/formik";
-import { Button, Toastr } from "neetoui";
+import { Button, Toastr, Label } from "neetoui";
 
 import {
   newContactInitialValues as initialValues,
@@ -38,11 +38,10 @@ export default function NewContactForm({ onClose, refetch }) {
             placeholder="Department"
             name="department"
           />
-          <Switch
-            label="Add to Basecamp"
-            name="addToBaseCamp"
-            className="flex-row-reverse justify-between"
-          />
+          <div className="flex justify-between">
+            <Label>Add to Basecamp</Label>
+            <Switch name="addToBaseCamp" />
+          </div>
           <div className="nui-pane__footer nui-pane__footer--absolute space-x-4">
             <Button
               onClick={onClose}

--- a/app/javascript/src/components/Dashboard/Notes/NoteTable.jsx
+++ b/app/javascript/src/components/Dashboard/Notes/NoteTable.jsx
@@ -86,7 +86,7 @@ export default function NoteTable({
                 <Avatar contact={{ name: note.contact }} />
               </td>
               <td>
-                <div className="flex flex-row items-center justify-end space-x-3">
+                <div className="flex flex-row items-center justify-center space-x-3">
                   <Tooltip content="Edit" position="bottom">
                     <Button icon="ri-pencil-line" style="icon" />
                   </Tooltip>


### PR DESCRIPTION
Fixes #16 

- Added` justify-center` for wrapper `div` for IconButtons in notes and contacts listing pages.
- Added spacing between `IconButtons` on contact listing page.
- Added Label component to the new contacts form page.
- Removed the extra margin on the Add to basecamp field